### PR TITLE
refactor: Use reference toConfiguration struct to pass around

### DIFF
--- a/software/raspberrypi/backend/src/configuration.rs
+++ b/software/raspberrypi/backend/src/configuration.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 
 use hardware::{doorswitch, lock, lockswitch};
 
+pub type ConfigurationRef = &'static Configuration;
+
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub struct Server {
     pub ipaddress: std::net::IpAddr,

--- a/software/raspberrypi/backend/src/logic.rs
+++ b/software/raspberrypi/backend/src/logic.rs
@@ -3,16 +3,16 @@ use tracing::info;
 
 use hardware::{doorswitch, lock, lockswitch, lockswitch::StateTrait, Direction};
 
-use crate::configuration::Configuration;
+use crate::configuration::ConfigurationRef;
 
 pub async fn logic(
-    configuration: &Configuration,
+    configuration: ConfigurationRef,
     mut receiver: Receiver<Direction>,
     spaceapi_sender: Sender<bool>,
 ) {
-    let lockswitch = lockswitch::LockSwitch::new(configuration.lockswitch, spaceapi_sender);
-    let _doorswitch = doorswitch::DoorSwitch::new(configuration.doorswitch);
-    let mut lock = lock::Lock::new(configuration.lockmotor);
+    let lockswitch = lockswitch::LockSwitch::new(&configuration.lockswitch, spaceapi_sender);
+    let _doorswitch = doorswitch::DoorSwitch::new(&configuration.doorswitch);
+    let mut lock = lock::Lock::new(&configuration.lockmotor);
     let mut is_open;
 
     while let Some(msg) = receiver.recv().await {

--- a/software/raspberrypi/backend/src/main.rs
+++ b/software/raspberrypi/backend/src/main.rs
@@ -1,3 +1,5 @@
+use std::boxed::Box;
+
 use anyhow::{Error, Result};
 use clap::Parser;
 use shadow_rs::shadow;
@@ -26,12 +28,12 @@ struct Args {
     spaceapi: bool,
 }
 
-fn load_configuration() -> Result<(configuration::Configuration, Args), Error> {
+fn load_configuration() -> Result<(configuration::ConfigurationRef, Args), Error> {
     // Load .env file
     dotenvy::dotenv().ok();
 
     // Read configuration from files and environment
-    let configuration = configuration::Configuration::new()?;
+    let configuration = Box::leak(Box::new(configuration::Configuration::new()?));
 
     // Read commandline arguments
     let args = Args::parse();
@@ -61,7 +63,7 @@ async fn main() -> Result<(), Error> {
         return Ok(());
     }
 
-    run(&configuration).await?;
+    run(configuration).await?;
 
     Ok(())
 }

--- a/software/raspberrypi/backend/src/notifyer.rs
+++ b/software/raspberrypi/backend/src/notifyer.rs
@@ -4,7 +4,7 @@ use secrecy::ExposeSecret;
 use tokio::sync::mpsc::Receiver;
 use tracing::{error, info};
 
-use crate::configuration::SpaceAPI;
+use crate::configuration::{ConfigurationRef, SpaceAPI};
 
 // async fn mqtt(state: bool) {
 //     info!("MQTT");
@@ -42,7 +42,7 @@ use crate::configuration::SpaceAPI;
 //     // }
 // }
 
-async fn spaceapi(configuration: &SpaceAPI, state: bool) {
+async fn spaceapi(configuration: &'static SpaceAPI, state: bool) {
     info!("SpaceAPI {state:?}");
 
     if configuration.enable {
@@ -78,10 +78,10 @@ async fn spaceapi(configuration: &SpaceAPI, state: bool) {
     }
 }
 
-pub async fn notify(configuration: &SpaceAPI, mut receiver: Receiver<bool>) {
+pub async fn notify(configuration: ConfigurationRef, mut receiver: Receiver<bool>) {
     while let Some(state) = receiver.recv().await {
         // let mqtt = mqtt(state);
-        let _spaceapi = spaceapi(configuration, state).await;
+        let _spaceapi = spaceapi(&configuration.spaceapi, state).await;
         // tokio::join!(mqtt, spaceapi);
     }
 }

--- a/software/raspberrypi/hardware/src/doorswitch.rs
+++ b/software/raspberrypi/hardware/src/doorswitch.rs
@@ -70,7 +70,7 @@ impl DoorSwitch {
         target_env = "musl",
         target_os = "linux"
     ))]
-    pub fn new(configuration: Configuration) -> Self {
+    pub fn new(configuration: &'static Configuration) -> Self {
         let mut gpio = Gpio::new()
             .unwrap()
             .get(configuration.pin)
@@ -91,7 +91,7 @@ impl DoorSwitch {
 
     #[must_use]
     #[cfg(all(target_arch = "x86_64", any(target_os = "macos", target_os = "linux")))]
-    pub fn new(_configuration: Configuration) -> Self {
+    pub fn new(_configuration: &'static Configuration) -> Self {
         Self::check_state_file();
 
         std::thread::spawn(move || {

--- a/software/raspberrypi/hardware/src/lock.rs
+++ b/software/raspberrypi/hardware/src/lock.rs
@@ -52,12 +52,12 @@ pub trait StateTrait {
 #[derive(Debug, Clone, Copy)]
 pub struct Lock {
     state: State,
-    configuration: Configuration,
+    configuration: &'static Configuration,
 }
 
 impl Lock {
     #[must_use]
-    pub fn new(configuration: Configuration) -> Self {
+    pub fn new(configuration: &'static Configuration) -> Self {
         Self {
             state: State::Locked,
             configuration,

--- a/software/raspberrypi/hardware/src/lockswitch.rs
+++ b/software/raspberrypi/hardware/src/lockswitch.rs
@@ -70,7 +70,10 @@ impl LockSwitch {
         target_env = "musl",
         target_os = "linux"
     ))]
-    pub fn new(configuration: Configuration, sender: tokio::sync::mpsc::Sender<bool>) -> Self {
+    pub fn new(
+        configuration: &'static Configuration,
+        sender: tokio::sync::mpsc::Sender<bool>,
+    ) -> Self {
         let mut gpio = Gpio::new()
             .unwrap()
             .get(configuration.pin)
@@ -100,7 +103,10 @@ impl LockSwitch {
 
     #[must_use]
     #[cfg(all(target_arch = "x86_64", any(target_os = "macos", target_os = "linux")))]
-    pub fn new(_configuration: Configuration, sender: tokio::sync::mpsc::Sender<bool>) -> Self {
+    pub fn new(
+        _configuration: &'static Configuration,
+        sender: tokio::sync::mpsc::Sender<bool>,
+    ) -> Self {
         Self::check_state_file();
 
         std::thread::spawn(move || {

--- a/software/raspberrypi/hardware/src/motor.rs
+++ b/software/raspberrypi/hardware/src/motor.rs
@@ -67,7 +67,7 @@ pub fn run(configuration: Configuration, direction: Direction) {
 }
 
 #[cfg(all(target_arch = "x86_64", any(target_os = "macos", target_os = "linux")))]
-pub fn run(configuration: Configuration, direction: Direction) {
+pub fn run(configuration: &'static Configuration, direction: Direction) {
     dbg!(configuration);
     println!("Debug {direction:?}");
 


### PR DESCRIPTION
Use the method from https://kerkour.com/rust-box-leak-static-reference to pass around the configuration structure.