### PR TITLE
spaceapi: add CORS header and cleanup response

### DIFF
--- a/software/spaceapi_backend/index.php
+++ b/software/spaceapi_backend/index.php
@@ -3,5 +3,6 @@
 $doorStatus = file_get_contents('door_status.txt');
 
 header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
 
-echo '{"api":"0.13","api_compatibility":["14"],"space":"section77","logo":"https://section77.de/static/section77_logo_vector.svg","url":"https://section77.de/","location":{"address":"Hauptstraße 1, 77652 Offenburg, Germany","lat":48.4771,"lon":7.9461},"contact":{"twitter":"@section77de","email":"info@section77.de","mastodon":"@section77@chaos.social"},"feeds":{"calendar":{"type":"ical","url":"https://section77.de/section77.ics"}},"issue_report_channels":["email"],"state":{"open":' . ($doorStatus === 'open' ? 'true' : 'false') . '},"sensors":{"people_now_present":[{"location":"Gleis0","value":0}]},"ext_ccc":"chaostreff","versions":{"spaceapi-rs":"0.9.0","spaceapi-server-rs":"0.8.0"}}';
+echo '{"api":"0.13","api_compatibility":["14"],"space":"section77","logo":"https://section77.de/static/section77_logo_vector.svg","url":"https://section77.de/","location":{"address":"Hauptstraße 1, 77652 Offenburg, Germany","lat":48.4771,"lon":7.9461},"contact":{"twitter":"@section77de","email":"info@section77.de","mastodon":"@section77@chaos.social"},"feeds":{"calendar":{"type":"ical","url":"https://section77.de/section77.ics"}},"issue_report_channels":["email"],"state":{"open":' . ($doorStatus === 'open' ? 'true' : 'false') . '},"ext_ccc":"chaostreff"}';


### PR DESCRIPTION
This MR adds CORS headers to the SpaceAPI response in order to fix the [mapall.space status page](https://mapall.space/onespace.php?space=section77).

Additonally, it streamlines the API response by:
- removing the "sensors" property, which is useless when returning a static string
- removing the "versions" property, which doesn't make any sense since we're not using spaceapi-rs any more